### PR TITLE
Minor optimizations for tensorrent hardware

### DIFF
--- a/src/boltz/model/modules/tenstorrent.py
+++ b/src/boltz/model/modules/tenstorrent.py
@@ -637,6 +637,7 @@ class TorchWrapper(nn.Module):
         self.module = None
         global mesh_device
         if mesh_device is None:
+            ttnn.device.EnablePersistentKernelCache()
             mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 2))
             mesh_device.enable_program_cache()
         self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(

--- a/src/boltz/model/modules/tenstorrent.py
+++ b/src/boltz/model/modules/tenstorrent.py
@@ -363,9 +363,8 @@ class Transition(Module):
             compute_kernel_config=self.compute_kernel_config,
         )
         x_1 = ttnn.linear(
-            x_norm, self.fc1_weight, compute_kernel_config=self.compute_kernel_config
+            x_norm, self.fc1_weight, activation="silu", compute_kernel_config=self.compute_kernel_config
         )
-        x_1 = ttnn.silu(x_1)
         x_2 = ttnn.linear(
             x_norm, self.fc2_weight, compute_kernel_config=self.compute_kernel_config
         )


### PR DESCRIPTION
This PR provides the following changes

1. Enable persistent cache. Reducing start up time. For `examples/prot.yaml` runtime dropped from 45s to 33 on a QuietBox (just kernel compilation time)
2. Fuse linear with silu. Minimal performance change but nice to have.

I tried messing with using L1 tensors and can get up to 10% overall runtime speedup. But is unsure if my use would cause major trouble on larger workloads so did not include them.